### PR TITLE
New path for MQTT in Valetudo UI

### DIFF
--- a/docs/_pages/integrations/mqtt.md
+++ b/docs/_pages/integrations/mqtt.md
@@ -7,7 +7,7 @@ order: 20
 # MQTT integration
 
 To make your robot talk to your MQTT broker and integrate with home automation software, such as but not limited to
-Home Assistant, openHAB and Node-RED, configure MQTT via Valetudo's web interface (Settings → MQTT).
+Home Assistant, openHAB and Node-RED, configure MQTT via Valetudo's web interface (Hamburger Menu → Connectivity → MQTT Connectivity).
 
 ## Autodiscovery
 


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [x] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


# Description (Type A)

I just rooted, installed and was configuring Valetudo when I could not find the mentioned Settings -> MQTT menu anywhere. 

These are small little details but will help newcomers with knowing where to click instead. 

<!-- This link is required -->
Feature discussion thread: None, I think this is a small little 'typo' fix that has no impact on the code whatsoever, it just clarifies stuff for newbies.